### PR TITLE
Fix default maxValue

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,7 +16,7 @@ const header_text_line3 = $("#third-line");
 const svgns = "http://www.w3.org/2000/svg";
 
 let minValue = 0;
-let maxValue = 0;
+let maxValue = 10000;
 let random_number = 0;
 
 // get the values from URL parameters


### PR DESCRIPTION
Without giving URL get parameters the app will always use 0 as random number. This happened to me when adding it to an apple home screen as web app link.

Fix this by setting the default max value to 10000.